### PR TITLE
[limit_library_search_by_ffprobe_data] 0.0.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 
+**<span style="color:#56adda">0.0.3</span>**
+- updated ffmpeg helper lib to latest version
+
 **<span style="color:#56adda">0.0.2</span>**
 - Refactor plugin to support JSONata queries of the FFprobe data
 

--- a/info.json
+++ b/info.json
@@ -11,5 +11,5 @@
         "on_library_management_file_test": 0
     },
     "tags": "audio,video,ffmpeg",
-    "version": "0.0.2"
+    "version": "0.0.3"
 }

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+    plugins.__init__.py
+
+    Written by:               Josh.5 <jsunnex@gmail.com>
+    Date:                     04 Sep 2021, (11:03 AM)
+
+    Copyright:
+        Copyright (C) 2021 Josh Sunnex
+
+        This program is free software: you can redistribute it and/or modify it under the terms of the GNU General
+        Public License as published by the Free Software Foundation, version 3.
+
+        This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+        implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+        for more details.
+
+        You should have received a copy of the GNU General Public License along with this program.
+        If not, see <https://www.gnu.org/licenses/>.
+
+"""


### PR DESCRIPTION
deleted and readded ffmpeg helper library to take advantage of new additions in the helper library since the plugin was originally made. Ran into a case yesterday where user of the plugin wished to limit based on chapters - @ time of plugin's release "show_chapters" was not in probe.py and it is now, so this will enable that useage.